### PR TITLE
Fix activation of the plugin

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ import {
 } from "coc.nvim";
 import { LSP_NAME } from "./constants";
 
-export default async function activate(context: ExtensionContext): Promise<void> {
+export async function activate(context: ExtensionContext): Promise<void> {
   const config = workspace.getConfiguration("zig");
 
   const zlsPath = config.get("path", "");

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,7 @@ export default async function activate(context: ExtensionContext): Promise<void>
   const zlsPath = config.get("path", "");
 
   // To turn off the extension
-  if (!config.get<boolean>("enable", true)) {
+  if (!config.get<boolean>("enabled", true)) {
     return;
   }
 


### PR DESCRIPTION
Fixes #1 

## Scope
In order for this plugin to be activated named export should be
used in the resulting bundle. `exports.activate` according to the
documentation.

## Tested
- Tested this by locally linking the folder to the ~/.coc extensions